### PR TITLE
Rename anyone_is_owner to open_permission

### DIFF
--- a/src/boards/db.rs
+++ b/src/boards/db.rs
@@ -71,7 +71,7 @@ pub async fn update(
     .fluent()
     .update()
     .fields(
-      paths!(BoardMessage::{name, cards_open, voting_open, ice_breaking, data, anyone_is_owner})
+      paths!(BoardMessage::{name, cards_open, voting_open, ice_breaking, data, open_permission})
         .into_iter()
         .filter(|f| serialised_board.get(f).is_some()),
     )
@@ -136,7 +136,7 @@ mod tests {
       voting_open: Some(false),
       ice_breaking: None,
       data: None,
-      anyone_is_owner: None,
+      open_permission: None,
     }
   }
 
@@ -177,7 +177,7 @@ mod tests {
         voting_open: None,
         ice_breaking: None,
         data: None,
-        anyone_is_owner: None,
+        open_permission: None,
       },
     )
     .await
@@ -189,7 +189,7 @@ mod tests {
 
   #[tokio::test]
   #[ignore = "requires Firestore emulator: FIRESTORE_EMULATOR_HOST=localhost:8080"]
-  async fn new_board_with_anyone_is_owner_true_persists() {
+  async fn new_board_with_open_permission_true_persists() {
     let db = emulator_db().await;
     let participant = test_participant();
     let board = new(
@@ -201,24 +201,24 @@ mod tests {
         voting_open: Some(true),
         ice_breaking: None,
         data: None,
-        anyone_is_owner: Some(true),
+        open_permission: Some(true),
       },
     )
     .await
     .unwrap();
-    assert!(board.anyone_is_owner);
+    assert!(board.open_permission);
     let fetched = get(&db, &board.id).await.unwrap();
-    assert!(fetched.anyone_is_owner);
+    assert!(fetched.open_permission);
     delete(&db, &board.id).await.unwrap();
   }
 
   #[tokio::test]
   #[ignore = "requires Firestore emulator: FIRESTORE_EMULATOR_HOST=localhost:8080"]
-  async fn update_board_anyone_is_owner_persists() {
+  async fn update_board_open_permission_persists() {
     let db = emulator_db().await;
     let participant = test_participant();
     let board = new(&db, &participant, board_msg("Toggle Anyone Is Owner")).await.unwrap();
-    assert!(!board.anyone_is_owner);
+    assert!(!board.open_permission);
     let updated = update(
       &db,
       &board.id,
@@ -228,20 +228,20 @@ mod tests {
         voting_open: None,
         ice_breaking: None,
         data: None,
-        anyone_is_owner: Some(true),
+        open_permission: Some(true),
       },
     )
     .await
     .unwrap();
-    assert!(updated.anyone_is_owner);
+    assert!(updated.open_permission);
     let fetched = get(&db, &board.id).await.unwrap();
-    assert!(fetched.anyone_is_owner);
+    assert!(fetched.open_permission);
     delete(&db, &board.id).await.unwrap();
   }
 
   #[tokio::test]
   #[ignore = "requires Firestore emulator: FIRESTORE_EMULATOR_HOST=localhost:8080"]
-  async fn update_board_anyone_is_owner_toggle_off_persists() {
+  async fn update_board_open_permission_toggle_off_persists() {
     let db = emulator_db().await;
     let participant = test_participant();
     let board = new(
@@ -253,12 +253,12 @@ mod tests {
         voting_open: Some(true),
         ice_breaking: None,
         data: None,
-        anyone_is_owner: Some(true),
+        open_permission: Some(true),
       },
     )
     .await
     .unwrap();
-    assert!(board.anyone_is_owner);
+    assert!(board.open_permission);
     let updated = update(
       &db,
       &board.id,
@@ -268,14 +268,14 @@ mod tests {
         voting_open: None,
         ice_breaking: None,
         data: None,
-        anyone_is_owner: Some(false),
+        open_permission: Some(false),
       },
     )
     .await
     .unwrap();
-    assert!(!updated.anyone_is_owner);
+    assert!(!updated.open_permission);
     let fetched = get(&db, &board.id).await.unwrap();
-    assert!(!fetched.anyone_is_owner);
+    assert!(!fetched.open_permission);
     delete(&db, &board.id).await.unwrap();
   }
 

--- a/src/boards/models.rs
+++ b/src/boards/models.rs
@@ -16,7 +16,7 @@ pub struct BoardMessage {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub data: Option<serde_json::Value>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub anyone_is_owner: Option<bool>,
+  pub open_permission: Option<bool>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -28,7 +28,7 @@ pub struct Board {
   pub ice_breaking: String,
   pub created_at: i64,
   pub owner: FirestoreReference,
-  pub anyone_is_owner: bool,
+  pub open_permission: bool,
   pub data: serde_json::Value,
 }
 
@@ -40,7 +40,7 @@ pub struct NewBoard {
   pub ice_breaking: Option<String>,
   pub created_at: FirestoreTimestamp,
   pub owner: Option<FirestoreReference>,
-  pub anyone_is_owner: bool,
+  pub open_permission: bool,
   pub data: serde_json::Value,
 }
 
@@ -54,7 +54,7 @@ pub struct BoardInFirestore {
   pub ice_breaking: Option<String>,
   pub created_at: Option<FirestoreTimestamp>,
   pub owner: FirestoreReference,
-  pub anyone_is_owner: Option<bool>,
+  pub open_permission: Option<bool>,
   pub data: serde_json::Value,
 }
 
@@ -67,7 +67,7 @@ impl From<BoardMessage> for NewBoard {
       ice_breaking: board.ice_breaking,
       created_at: FirestoreTimestamp(Utc::now()),
       owner: None,
-      anyone_is_owner: board.anyone_is_owner.unwrap_or(false),
+      open_permission: board.open_permission.unwrap_or(false),
       data: board
         .data
         .unwrap_or_else(|| serde_json::Value::Object(Map::new())),
@@ -89,7 +89,7 @@ impl From<BoardInFirestore> for Board {
         .0
         .timestamp(),
       owner: board.owner,
-      anyone_is_owner: board.anyone_is_owner.unwrap_or(false),
+      open_permission: board.open_permission.unwrap_or(false),
       data: board.data,
     }
   }
@@ -104,7 +104,7 @@ pub struct BoardResponse {
   pub ice_breaking: String,
   pub created_at: i64,
   pub owner: bool,
-  pub anyone_is_owner: bool,
+  pub open_permission: bool,
   pub data: serde_json::Value,
 }
 
@@ -118,7 +118,7 @@ impl BoardResponse {
       ice_breaking: board.ice_breaking,
       created_at: board.created_at,
       owner: &board.owner == participant_id,
-      anyone_is_owner: board.anyone_is_owner,
+      open_permission: board.open_permission,
       data: board.data,
     }
   }
@@ -144,7 +144,7 @@ mod tests {
       ice_breaking: Some("How are you?".to_string()),
       created_at: None,
       owner: ref_(owner),
-      anyone_is_owner: None,
+      open_permission: None,
       data: serde_json::Value::Object(serde_json::Map::new()),
     }
   }
@@ -157,7 +157,7 @@ mod tests {
       voting_open: None,
       ice_breaking: None,
       data: None,
-      anyone_is_owner: None,
+      open_permission: None,
     };
     let b: NewBoard = msg.into();
     assert_eq!(b.name, "");
@@ -176,7 +176,7 @@ mod tests {
       voting_open: Some(false),
       ice_breaking: Some("Icebreaker!".to_string()),
       data: Some(serde_json::json!({"key": "value"})),
-      anyone_is_owner: None,
+      open_permission: None,
     };
     let b: NewBoard = msg.into();
     assert_eq!(b.name, "My Retro");
@@ -219,57 +219,57 @@ mod tests {
   }
 
   #[test]
-  fn board_response_owner_false_for_non_owner_even_when_anyone_is_owner() {
+  fn board_response_owner_false_for_non_owner_even_when_open_permission() {
     let participant = ref_("participants/user2");
     let mut raw = board_in_firestore("b1", "participants/user1");
-    raw.anyone_is_owner = Some(true);
+    raw.open_permission = Some(true);
     let board: Board = raw.into();
     let resp = BoardResponse::from_board(board, &participant);
     assert!(!resp.owner);
-    assert!(resp.anyone_is_owner);
+    assert!(resp.open_permission);
   }
 
   #[test]
-  fn board_response_anyone_is_owner_false_by_default() {
+  fn board_response_open_permission_false_by_default() {
     let participant = ref_("participants/user1");
     let board: Board = board_in_firestore("b1", "participants/user1").into();
     let resp = BoardResponse::from_board(board, &participant);
-    assert!(!resp.anyone_is_owner);
+    assert!(!resp.open_permission);
   }
 
   #[test]
-  fn board_in_firestore_anyone_is_owner_none_defaults_to_false() {
+  fn board_in_firestore_open_permission_none_defaults_to_false() {
     let raw = board_in_firestore("b1", "participants/user1");
     let board: Board = raw.into();
-    assert!(!board.anyone_is_owner);
+    assert!(!board.open_permission);
   }
 
   #[test]
-  fn board_message_anyone_is_owner_none_defaults_to_false() {
+  fn board_message_open_permission_none_defaults_to_false() {
     let msg = BoardMessage {
       name: None,
       cards_open: None,
       voting_open: None,
       ice_breaking: None,
       data: None,
-      anyone_is_owner: None,
+      open_permission: None,
     };
     let b: NewBoard = msg.into();
-    assert!(!b.anyone_is_owner);
+    assert!(!b.open_permission);
   }
 
   #[test]
-  fn board_message_anyone_is_owner_true_is_preserved() {
+  fn board_message_open_permission_true_is_preserved() {
     let msg = BoardMessage {
       name: None,
       cards_open: None,
       voting_open: None,
       ice_breaking: None,
       data: None,
-      anyone_is_owner: Some(true),
+      open_permission: Some(true),
     };
     let b: NewBoard = msg.into();
-    assert!(b.anyone_is_owner);
+    assert!(b.open_permission);
   }
 
   #[test]

--- a/src/boards/routes.rs
+++ b/src/boards/routes.rs
@@ -22,10 +22,10 @@ fn check_update_permission(
   message: &BoardMessage,
 ) -> Result<(), Error> {
   let is_owner = board.owner == *participant;
-  if !is_owner && !board.anyone_is_owner {
+  if !is_owner && !board.open_permission {
     return Err(Error::Forbidden);
   }
-  if !is_owner && message.anyone_is_owner.is_some() {
+  if !is_owner && message.open_permission.is_some() {
     return Err(Error::Forbidden);
   }
   Ok(())
@@ -155,7 +155,7 @@ mod tests {
     FirestoreReference(s.to_string())
   }
 
-  fn make_board(owner: &str, anyone_is_owner: bool) -> Board {
+  fn make_board(owner: &str, open_permission: bool) -> Board {
     Board {
       id: "board1".to_string(),
       name: "Test".to_string(),
@@ -164,19 +164,19 @@ mod tests {
       ice_breaking: "".to_string(),
       created_at: Utc::now().timestamp(),
       owner: ref_(owner),
-      anyone_is_owner,
+      open_permission,
       data: serde_json::Value::Object(Map::new()),
     }
   }
 
-  fn msg(anyone_is_owner: Option<bool>) -> BoardMessage {
+  fn msg(open_permission: Option<bool>) -> BoardMessage {
     BoardMessage {
       name: None,
       cards_open: None,
       voting_open: None,
       ice_breaking: None,
       data: None,
-      anyone_is_owner,
+      open_permission,
     }
   }
 
@@ -193,7 +193,7 @@ mod tests {
   }
 
   #[test]
-  fn non_owner_cannot_delete_even_when_anyone_is_owner() {
+  fn non_owner_cannot_delete_even_when_open_permission() {
     let board = make_board("participants/owner", true);
     assert!(check_delete_permission(&board, &ref_("participants/other")).is_err());
   }
@@ -205,19 +205,19 @@ mod tests {
   }
 
   #[test]
-  fn non_owner_blocked_when_anyone_is_owner_false() {
+  fn non_owner_blocked_when_open_permission_false() {
     let board = make_board("participants/owner", false);
     assert!(check_update_permission(&board, &ref_("participants/other"), &msg(None)).is_err());
   }
 
   #[test]
-  fn non_owner_allowed_when_anyone_is_owner_true() {
+  fn non_owner_allowed_when_open_permission_true() {
     let board = make_board("participants/owner", true);
     assert!(check_update_permission(&board, &ref_("participants/other"), &msg(None)).is_ok());
   }
 
   #[test]
-  fn non_owner_cannot_toggle_anyone_is_owner_off() {
+  fn non_owner_cannot_toggle_open_permission_off() {
     let board = make_board("participants/owner", true);
     assert!(
       check_update_permission(&board, &ref_("participants/other"), &msg(Some(false))).is_err()
@@ -225,7 +225,7 @@ mod tests {
   }
 
   #[test]
-  fn non_owner_cannot_toggle_anyone_is_owner_on() {
+  fn non_owner_cannot_toggle_open_permission_on() {
     let board = make_board("participants/owner", false);
     assert!(
       check_update_permission(&board, &ref_("participants/other"), &msg(Some(true))).is_err()
@@ -233,7 +233,7 @@ mod tests {
   }
 
   #[test]
-  fn owner_can_toggle_anyone_is_owner_on() {
+  fn owner_can_toggle_open_permission_on() {
     let board = make_board("participants/owner", false);
     assert!(
       check_update_permission(&board, &ref_("participants/owner"), &msg(Some(true))).is_ok()
@@ -241,7 +241,7 @@ mod tests {
   }
 
   #[test]
-  fn owner_can_toggle_anyone_is_owner_off() {
+  fn owner_can_toggle_open_permission_off() {
     let board = make_board("participants/owner", true);
     assert!(
       check_update_permission(&board, &ref_("participants/owner"), &msg(Some(false))).is_ok()

--- a/src/cards/db.rs
+++ b/src/cards/db.rs
@@ -304,7 +304,7 @@ mod tests {
         voting_open: Some(true),
         ice_breaking: None,
         data: None,
-        anyone_is_owner: None,
+        open_permission: None,
       },
     )
     .await

--- a/src/columns/routes.rs
+++ b/src/columns/routes.rs
@@ -113,7 +113,7 @@ mod tests {
       ice_breaking: "".to_string(),
       created_at: Utc::now().timestamp(),
       owner: ref_(owner),
-      anyone_is_owner: false,
+      open_permission: false,
       data: serde_json::Value::Object(Map::new()),
     }
   }

--- a/src/integration_tests/board_tests.rs
+++ b/src/integration_tests/board_tests.rs
@@ -24,7 +24,7 @@ async fn create_returns_200_with_correct_fields() {
   assert_eq!(json["cards_open"], true);
   assert_eq!(json["voting_open"], true);
   assert_eq!(json["owner"], true);
-  assert_eq!(json["anyone_is_owner"], false);
+  assert_eq!(json["open_permission"], false);
 
   boards::db::delete(&db, &board_id).await.unwrap();
 }
@@ -169,7 +169,7 @@ async fn update_as_non_owner_returns_403() {
 
 #[tokio::test]
 #[ignore = "requires Firestore emulator: FIRESTORE_EMULATOR_HOST=localhost:8080"]
-async fn update_as_non_owner_with_anyone_is_owner_returns_200() {
+async fn update_as_non_owner_with_open_permission_returns_200() {
   let db = emulator_db().await;
   let app = make_app!(db.clone());
 
@@ -177,7 +177,7 @@ async fn update_as_non_owner_with_anyone_is_owner_returns_200() {
     &app,
     TestRequest::post()
       .uri("/boards")
-      .set_json(json!({"name": "Open Board", "anyone_is_owner": true}))
+      .set_json(json!({"name": "Open Board", "open_permission": true}))
       .to_request(),
   )
   .await;

--- a/src/integration_tests/column_tests.rs
+++ b/src/integration_tests/column_tests.rs
@@ -166,7 +166,7 @@ async fn update_as_non_owner_returns_403() {
 
 #[tokio::test]
 #[ignore = "requires Firestore emulator: FIRESTORE_EMULATOR_HOST=localhost:8080"]
-async fn update_as_non_owner_with_anyone_is_owner_still_returns_403() {
+async fn update_as_non_owner_with_open_permission_still_returns_403() {
   let db = emulator_db().await;
   let app = make_app!(db.clone());
 
@@ -174,7 +174,7 @@ async fn update_as_non_owner_with_anyone_is_owner_still_returns_403() {
     &app,
     TestRequest::post()
       .uri("/boards")
-      .set_json(json!({"anyone_is_owner": true}))
+      .set_json(json!({"open_permission": true}))
       .to_request(),
   )
   .await;


### PR DESCRIPTION
## Summary
- Renames the `anyone_is_owner` field to `open_permission` across all structs, tests, and JSON keys

## Test plan
- [x] `cargo check` passes (verified locally)
- [x] Run unit tests: `cargo test`
- [x] Run integration tests against Firestore emulator: `FIRESTORE_EMULATOR_HOST=localhost:8080 cargo test -- --ignored`

🤖 Generated with [Claude Code](https://claude.com/claude-code)